### PR TITLE
Powerups

### DIFF
--- a/Assets/Prefabs/NeutralClone.prefab
+++ b/Assets/Prefabs/NeutralClone.prefab
@@ -149,5 +149,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f3880ac82a43da44db41a995648d0959, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  vaultForce: 10
+  vaultForce: 5
   playerScript: {fileID: 0}

--- a/Assets/Prefabs/NeutralClone.prefab
+++ b/Assets/Prefabs/NeutralClone.prefab
@@ -1,0 +1,153 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &198813387838526515
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5316275212065931114}
+  - component: {fileID: 7469419699065467374}
+  - component: {fileID: 3534327086751467174}
+  - component: {fileID: 2143271567244423877}
+  - component: {fileID: 251050430053597948}
+  - component: {fileID: 8882998480603745592}
+  m_Layer: 0
+  m_Name: NeutralClone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5316275212065931114
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198813387838526515}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.223, y: 0.23129678, z: 0.18822}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7469419699065467374
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198813387838526515}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3534327086751467174
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198813387838526515}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &2143271567244423877
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198813387838526515}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1.0000001, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &251050430053597948
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198813387838526515}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &8882998480603745592
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198813387838526515}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f3880ac82a43da44db41a995648d0959, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  vaultForce: 10
+  playerScript: {fileID: 0}

--- a/Assets/Prefabs/NeutralClone.prefab.meta
+++ b/Assets/Prefabs/NeutralClone.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d86b48693a7339040a300fb92fafcf35
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NeutralClone.cs
+++ b/Assets/Scripts/NeutralClone.cs
@@ -1,25 +1,40 @@
 using UnityEngine;
+using System.Collections;
 
 public class NeutralClone : MonoBehaviour
 {
-    public float vaultForce = 10f;
+    public float vaultForce = 0.0000001f; 
     private bool playerNearby = false;
     private GameObject player;
     public Player playerScript;
 
-    void Update()
+    private void Start()
+    {
+        StartCoroutine(PopInEffect());
+    }
+
+    private void Update()
     {
         if (playerNearby && Input.GetKeyDown(KeyCode.F))
         {
+            VaultPlayer();
+        }
+    }
+
+    private void VaultPlayer()
+    {
+        if (player != null)
+        {
             Rigidbody playerRb = player.GetComponent<Rigidbody>();
-            playerRb.linearVelocity = new Vector3(playerRb.linearVelocity.x, vaultForce, 0);
+
+            playerRb.AddForce(Vector3.up * vaultForce, ForceMode.Impulse);
+            Debug.Log("Vault Triggered: Force Applied = " + vaultForce);
 
             playerScript.ClearNeutralClone();
-
             Destroy(gameObject);
         }
-
     }
+
 
     private void OnTriggerEnter(Collider other)
     {
@@ -37,5 +52,21 @@ public class NeutralClone : MonoBehaviour
             playerNearby = false;
             player = null;
         }
+    }
+
+    private IEnumerator PopInEffect()
+    {
+        Vector3 originalScale = transform.localScale;
+        transform.localScale = Vector3.zero;
+
+        float duration = 0.3f;
+        float elapsed = 0;
+        while (elapsed < duration)
+        {
+            transform.localScale = Vector3.Lerp(Vector3.zero, originalScale, elapsed / duration);
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+        transform.localScale = originalScale;
     }
 }

--- a/Assets/Scripts/NeutralClone.cs
+++ b/Assets/Scripts/NeutralClone.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class NeutralClone : MonoBehaviour
+{
+    public float vaultForce = 10f;
+    private bool playerNearby = false;
+    private GameObject player;
+    public Player playerScript;
+
+    void Update()
+    {
+        if (playerNearby && Input.GetKeyDown(KeyCode.F))
+        {
+            Rigidbody playerRb = player.GetComponent<Rigidbody>();
+            playerRb.linearVelocity = new Vector3(playerRb.linearVelocity.x, vaultForce, 0);
+
+            playerScript.ClearNeutralClone();
+
+            Destroy(gameObject);
+        }
+
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            playerNearby = true;
+            player = other.gameObject;
+        }
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            playerNearby = false;
+            player = null;
+        }
+    }
+}

--- a/Assets/Scripts/NeutralClone.cs.meta
+++ b/Assets/Scripts/NeutralClone.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f3880ac82a43da44db41a995648d0959

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -23,13 +23,12 @@ public class Player : MonoBehaviour
     private UserInput input;
     private bool midJump = false;
 
-private void Start()
-{
-    rb = GetComponent<Rigidbody>();
-    input = FindObjectOfType<UserInput>(); // Look for the global input manager
-    currentHealth = maxHealth;
-}
-
+    private void Start()
+    {
+        rb = GetComponent<Rigidbody>();
+        input = FindObjectOfType<UserInput>(); // Look for the global input manager
+        currentHealth = maxHealth;
+    }
 
     private void Update()
     {
@@ -38,34 +37,38 @@ private void Start()
 
     private void HandleInput()
     {
+        Vector3 velocity = rb.linearVelocity;
+
         if (input.Left)
         {
             if (!midJump) transform.eulerAngles = new Vector3(0, 0, 0);
-            rb.linearVelocity = new Vector3(-speed, rb.linearVelocity.y, 0);
+            velocity.x = -speed;
         }
         else if (input.Right)
         {
             if (!midJump) transform.eulerAngles = new Vector3(0, 180, 0);
-            rb.linearVelocity = new Vector3(speed, rb.linearVelocity.y, 0);
+            velocity.x = speed;
         }
         else
         {
-            rb.linearVelocity = new Vector3(0, rb.linearVelocity.y, 0);
+            velocity.x = 0;
         }
 
         if (input.Jump && !midJump)
         {
-            rb.linearVelocity = new Vector3(rb.linearVelocity.x, jumpForce, 0);
+            velocity.y = jumpForce;
             midJump = true;
             input.ResetJump();
         }
 
+        rb.linearVelocity = velocity;
+
+        // Clone Summon
         if (Input.GetKeyDown(KeyCode.E) && activeNeutralClone == null)
         {
             SummonNeutralClone();
         }
     }
-
 
     private void OnCollisionEnter(Collision collision)
     {
@@ -120,6 +123,4 @@ private void Start()
     {
         activeNeutralClone = null;
     }
-
-
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -6,7 +6,14 @@ public class Player : MonoBehaviour
     public int maxHealth = 3;
     public int currentHealth;
     public int lives = 3;
+
+    [Header("HUD Interact")]
     public HUDManager hudManager;
+
+    [Header("Clone Summoning")]
+    public GameObject neutralClonePrefab;
+    public Transform cloneSpawnPoint;
+    private GameObject activeNeutralClone;
 
     [Header("Movement Settings")]
     [SerializeField] private float speed = 1.25f;
@@ -52,7 +59,13 @@ private void Start()
             midJump = true;
             input.ResetJump();
         }
+
+        if (Input.GetKeyDown(KeyCode.E) && activeNeutralClone == null)
+        {
+            SummonNeutralClone();
+        }
     }
+
 
     private void OnCollisionEnter(Collision collision)
     {
@@ -94,4 +107,19 @@ private void Start()
         currentHealth = maxHealth;
         Debug.Log("Player respawned.");
     }
+
+    private void SummonNeutralClone()
+    {
+        GameObject clone = Instantiate(neutralClonePrefab, cloneSpawnPoint.position, Quaternion.identity);
+        activeNeutralClone = clone;
+
+        clone.GetComponent<NeutralClone>().playerScript = this;
+    }
+
+    public void ClearNeutralClone()
+    {
+        activeNeutralClone = null;
+    }
+
+
 }


### PR DESCRIPTION
# Pull Request - Add Vaulting Power-Up Clone Feature

## Summary
This pull request introduces the Vaulting Power-Up Clone mechanic to enhance player movement and add a new gameplay element inspired by the Donkey Kong arcade platformer.

## Features Implemented
- **NeutralClone.cs**: A new clone type that allows the player to vault upwards when interacting with it.
  - Spawns with a smooth scale "pop-in" animation.
  - Detects player proximity and listens for the `F` key press.
  - Applies an upward force to the player using `Rigidbody.AddForce()` with `ForceMode.Impulse`.
  - Self-destructs after use and notifies the player script to clear the active clone reference.

- **Player.cs Enhancements**:
  - Refactored movement logic to preserve vertical velocity, enabling proper additive physics interactions like vaulting.
  - Clone spawning system updated to ensure only one active neutral clone exists at a time.
  - Introduced `SummonNeutralClone()` method, triggered by pressing `E`.
