### PR TITLE
fix: ladder climbing blocked by player hitbox size

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -142,8 +142,8 @@ CapsuleCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
+  m_Radius: 0.2
+  m_Height: 1
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &6818066303004943469
@@ -206,6 +206,7 @@ MonoBehaviour:
   cloneSpawnPoint: {fileID: 4847968933232643082}
   speed: 1.25
   jumpForce: 2.5
+  visual: {fileID: 0}
 --- !u!1 &8866671680025008123
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/TestingMovement.unity
+++ b/Assets/Scenes/TestingMovement.unity
@@ -711,11 +711,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5363012198542598786, guid: a1839a21c82ed224a9fce2aa6636e4dd, type: 3}
       propertyPath: m_Height
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5363012198542598786, guid: a1839a21c82ed224a9fce2aa6636e4dd, type: 3}
       propertyPath: m_Radius
-      value: 0.5
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6818066303004943469, guid: a1839a21c82ed224a9fce2aa6636e4dd, type: 3}
+      propertyPath: m_AngularDrag
+      value: 0.05
       objectReference: {fileID: 0}
     - target: {fileID: 6818066303004943469, guid: a1839a21c82ed224a9fce2aa6636e4dd, type: 3}
       propertyPath: m_Interpolate
@@ -751,7 +755,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8728852996766168014, guid: a1839a21c82ed224a9fce2aa6636e4dd, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.4614
+      value: -0.424
       objectReference: {fileID: 0}
     - target: {fileID: 8728852996766168014, guid: a1839a21c82ed224a9fce2aa6636e4dd, type: 3}
       propertyPath: m_LocalPosition.y

--- a/Assets/Scripts/Ladder.cs
+++ b/Assets/Scripts/Ladder.cs
@@ -4,11 +4,14 @@ public class LadderClimb : MonoBehaviour
 {
     private bool onLadder = false;
     private Rigidbody rb;
-    [SerializeField] private float climbSpeed = 0.75f;  
+    [SerializeField] private float climbSpeed = 0.75f;
+
+    private UserInput input;
 
     void Start()
     {
         rb = GetComponent<Rigidbody>();
+        input = FindObjectOfType<UserInput>();
     }
 
     void Update()
@@ -21,21 +24,19 @@ public class LadderClimb : MonoBehaviour
 
     void ClimbLadder()
     {
-
         rb.useGravity = false;
 
-    
-        float verticalInput = Input.GetAxisRaw("Vertical");
-
-        if (verticalInput != 0)
+        if (input.Up)
         {
-           
-            rb.linearVelocity = new Vector3(0, verticalInput * climbSpeed, 0);
+            rb.linearVelocity = new Vector3(rb.linearVelocity.x, climbSpeed, 0);
+        }
+        else if (input.Down)
+        {
+            rb.linearVelocity = new Vector3(rb.linearVelocity.x, -climbSpeed, 0);
         }
         else
         {
-         
-            rb.linearVelocity = new Vector3(0, 0, 0);
+            rb.linearVelocity = new Vector3(rb.linearVelocity.x, 0f, 0);
         }
     }
 

--- a/Assets/Scripts/UserInput.cs
+++ b/Assets/Scripts/UserInput.cs
@@ -5,12 +5,18 @@ public class UserInput : MonoBehaviour
     public bool Left { get; private set; }
     public bool Right { get; private set; }
     public bool Jump { get; private set; }
+    public bool Up { get; private set; }
+    public bool Down { get; private set; }
 
     void Update()
     {
-        Left = Input.GetKey(KeyCode.A);
-        Right = Input.GetKey(KeyCode.D);
+        
+        Left = Input.GetKey(KeyCode.A) || Input.GetKey(KeyCode.LeftArrow);
+        Right = Input.GetKey(KeyCode.D) || Input.GetKey(KeyCode.RightArrow);
         Jump = Input.GetKeyDown(KeyCode.Space);
+
+        Up = Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.UpArrow);
+        Down = Input.GetKey(KeyCode.S) || Input.GetKey(KeyCode.DownArrow);
     }
 
     public void ResetJump()


### PR DESCRIPTION
## Merge Request: Fix Ladder Climbing Collision & Input

**Description:**
Resolves the issue where the player could not climb through ladder openings. The primary cause was the player's collider being too large to fit through platform gaps. Also updated ladder logic to use `UserInput.cs` instead of raw Unity input.

**Related Issues:**
- Climbing collision getting stuck
- Transition from PlayerMovement to Player + UserInput

**Type of Change:**
- [x] Bug Fix
- [x] Input Refactor

**Checklist:**
- [x] LadderClimb now uses UserInput (W/S or ↑/↓)
- [x] Player collider resized to fit through platform gaps
- [x] Climbing works smoothly on all current ladders
- [x] Debugged "fat monkey" hitbox

**Additional Notes:**
> Our monkey was too fat. The bananas have been taken away. All is well now 🍌❌🐒
