### PR TITLE
Fix HUD lives counter and heart refresh on respawn

### DIFF
--- a/Assets/Prefabs/PlayerHud.prefab
+++ b/Assets/Prefabs/PlayerHud.prefab
@@ -197,6 +197,7 @@ RectTransform:
   - {fileID: 9218214400942185331}
   - {fileID: 2066582597274193589}
   - {fileID: 8702353276533906949}
+  - {fileID: 5827532547979843316}
   m_Father: {fileID: 559170130571901918}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -219,6 +220,7 @@ MonoBehaviour:
   scoreText: {fileID: 3341136290955593822}
   timerText: {fileID: 8803639236014146568}
   levelText: {fileID: 5094997796189307397}
+  livesText: {fileID: 6884587353197977739}
   heartIcons:
   - {fileID: 144404950915785400}
   - {fileID: 2448204649881236328}
@@ -628,6 +630,142 @@ MonoBehaviour:
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
   m_margin: {x: 0, y: 0, z: -139.91571, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5876984260480009791
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5827532547979843316}
+  - component: {fileID: 2849290158024823933}
+  - component: {fileID: 6884587353197977739}
+  m_Layer: 5
+  m_Name: LivesText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5827532547979843316
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5876984260480009791}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3842104907068801660}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -377, y: 119}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2849290158024823933
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5876984260480009791}
+  m_CullTransparentMesh: 1
+--- !u!114 &6884587353197977739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5876984260480009791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'LIVES: 3'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0

--- a/Assets/Scripts/HUDManager.cs
+++ b/Assets/Scripts/HUDManager.cs
@@ -7,18 +7,18 @@ public class HUDManager : MonoBehaviour
     public TMP_Text scoreText;
     public TMP_Text timerText;
     public TMP_Text levelText;
+    public TMP_Text livesText; // purely for displaying Player's lives
+
     public Image[] heartIcons;
 
     private int score = 0;
-    private int lives = 3;
     public int level = 1;
 
-    public float timeRemaining = 420f;  // Timer start
+    public float timeRemaining = 420f;
     private bool timerRunning = true;
 
     void Update()
     {
-
         if (timerRunning)
         {
             timeRemaining -= Time.deltaTime;
@@ -27,8 +27,8 @@ public class HUDManager : MonoBehaviour
                 timeRemaining = 0;
                 timerRunning = false;
                 Debug.Log("Time's up! Game Over.");
-                // We can call game over here
             }
+
             UpdateHUD();
         }
     }
@@ -37,17 +37,9 @@ public class HUDManager : MonoBehaviour
     {
         scoreText.text = "SCORE: " + score.ToString("D6");
         timerText.text = "TIME: " + Mathf.CeilToInt(timeRemaining).ToString();
-        levelText.text = "LEVEL: 1";
+        levelText.text = "LEVEL: " + level;
 
-        if (timeRemaining <= 60f)
-            timerText.color = Color.red;
-        else
-            timerText.color = Color.white;
-
-        for (int i = 0; i < heartIcons.Length; i++)
-        {
-            heartIcons[i].enabled = i < lives;
-        }
+        timerText.color = timeRemaining <= 60f ? Color.red : Color.white;
     }
 
     public void AddScore(int points)
@@ -56,16 +48,23 @@ public class HUDManager : MonoBehaviour
         UpdateHUD();
     }
 
-    public void LoseLife()
-    {
-        if (lives > 0)
-            lives--;
-        UpdateHUD();
-    }
-
     public void SetLevel(int newLevel)
     {
         level = newLevel;
         UpdateHUD();
+    }
+
+    public void SetHealth(int hp)
+    {
+        for (int i = 0; i < heartIcons.Length; i++)
+            heartIcons[i].enabled = false;
+
+        for (int i = 0; i < hp && i < heartIcons.Length; i++)
+            heartIcons[i].enabled = true;
+    }
+
+    public void SetLives(int lives)
+    {
+        livesText.text = "LIVES: " + lives.ToString();
     }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -33,6 +33,8 @@ public class Player : MonoBehaviour
         input = FindObjectOfType<UserInput>();
         currentHealth = maxHealth;
         animator = visual.GetComponent<Animator>();
+        hudManager.SetLives(lives);
+
     }
 
     private void Update()
@@ -95,7 +97,7 @@ public class Player : MonoBehaviour
         currentHealth -= amount;
         animator.SetTrigger("Hit");
         Debug.Log("Player took damage. Current HP: " + currentHealth);
-        hudManager.LoseLife();
+        hudManager.SetHealth(currentHealth);
         if (currentHealth <= 0)
         {
             Die();
@@ -105,6 +107,7 @@ public class Player : MonoBehaviour
     private void Die()
     {
         lives--;
+        hudManager.SetLives(lives);
         animator.SetTrigger("Die");
         Debug.Log("Player died. Lives remaining: " + lives);
 
@@ -119,10 +122,12 @@ public class Player : MonoBehaviour
         }
     }
 
+
     private void Respawn()
     {
         currentHealth = maxHealth;
-
+        hudManager.SetHealth(currentHealth);
+        hudManager.SetLives(lives);
         GameObject spawnPoint = GameObject.FindGameObjectWithTag("PlayerSpawn");
         if (spawnPoint != null)
         {


### PR DESCRIPTION
## Description
This PR fixes the HUD system so that the lives counter and hearts display correctly:
- Added `SetLives()` call in `Die()` and `Respawn()` methods in `Player.cs` to ensure UI stays in sync.
- Now the lives count updates on death, and hearts fully refresh on respawn.

## Related Issue
Fix HUD lives counter and heart sync (#)

## Type of Change
- [x] Bug Fix
- [x]   New Feature


## Checklist
- [x] Lives counter updates correctly on death
- [x] Hearts reset properly after respawn
- [x] Code compiles and runs with no warnings or errors

## Additional Notes
Lives now show using TMP text. Later, we can convert this into icon-based display for a more polished UI if needed.
